### PR TITLE
fix: prevent double slashes in import paths when output directory has…

### DIFF
--- a/cmd/utils/content/fiber/controller.go
+++ b/cmd/utils/content/fiber/controller.go
@@ -36,6 +36,8 @@ func Delete%[3]s(c *fiber.Ctx) error {
 
 func ControllerContent(model string, output string, moduleName string) string {
 	importPath := output
+	// Trim trailing slashes to avoid double slashes in imports
+	importPath = text.TrimTrailingSlash(importPath)
 	if importPath == "./" || importPath == "." || importPath == "" {
 		importPath = moduleName
 	} else {

--- a/cmd/utils/content/fiber/repository.go
+++ b/cmd/utils/content/fiber/repository.go
@@ -35,6 +35,8 @@ func Delete%[3]s(c *fiber.Ctx) error {
 
 func RepositoryContent(model string, output string, moduleName string) string {
 	importPath := output
+	// Trim trailing slashes to avoid double slashes in imports
+	importPath = text.TrimTrailingSlash(importPath)
 	if importPath == "./" || importPath == "." || importPath == "" {
 		importPath = moduleName
 	} else {

--- a/cmd/utils/content/fiber/routes.go
+++ b/cmd/utils/content/fiber/routes.go
@@ -23,6 +23,8 @@ func %[3]sRoutes(router fiber.Router) {
 
 func RoutesContent(model string, output string, moduleName string) string {
 	importPath := output
+	// Trim trailing slashes to avoid double slashes in imports
+	importPath = text.TrimTrailingSlash(importPath)
 	if importPath == "./" || importPath == "." || importPath == "" {
 		importPath = moduleName
 	} else {
@@ -33,8 +35,8 @@ func RoutesContent(model string, output string, moduleName string) string {
 			importPath = moduleName + "/" + importPath
 		}
 	}
-	return fmt.Sprintf(routes_content, 
-		importPath, 
+	return fmt.Sprintf(routes_content,
+		importPath,
 		model,
 		text.Capitalize(model),
 		text.ToSnakeCase(model),

--- a/cmd/utils/content/fiber/service.go
+++ b/cmd/utils/content/fiber/service.go
@@ -35,6 +35,8 @@ func Delete%[3]s(c *fiber.Ctx) error {
 
 func ServiceContent(model string, output string, moduleName string) string {
 	importPath := output
+	// Trim trailing slashes to avoid double slashes in imports
+	importPath = text.TrimTrailingSlash(importPath)
 	if importPath == "./" || importPath == "." || importPath == "" {
 		importPath = moduleName
 	} else {

--- a/cmd/utils/text/text.go
+++ b/cmd/utils/text/text.go
@@ -3,29 +3,31 @@ package text
 import "strings"
 
 func Pluralize(word string) string {
-	if word == "" { return "" }
-    word = strings.ToLower(word);
+	if word == "" {
+		return ""
+	}
+	word = strings.ToLower(word)
 
-    irregulars := map[string]string{
-		"person":   "people",
-		"child":    "children",
-		"man":      "men",
-		"woman":    "women",
-		"tooth":    "teeth",
-		"foot":     "feet",
-		"mouse":    "mice",
-		"goose":    "geese",
+	irregulars := map[string]string{
+		"person": "people",
+		"child":  "children",
+		"man":    "men",
+		"woman":  "women",
+		"tooth":  "teeth",
+		"foot":   "feet",
+		"mouse":  "mice",
+		"goose":  "geese",
 	}
 
-    if plural, ok := irregulars[word]; ok {
-        return plural
-    }
+	if plural, ok := irregulars[word]; ok {
+		return plural
+	}
 
-    if strings.HasSuffix(word, "y") {
-        return strings.TrimSuffix(word, "y") + "ies"
-    }
+	if strings.HasSuffix(word, "y") {
+		return strings.TrimSuffix(word, "y") + "ies"
+	}
 
-    if strings.HasSuffix(word, "ss") || strings.HasSuffix(word, "sh") ||
+	if strings.HasSuffix(word, "ss") || strings.HasSuffix(word, "sh") ||
 		strings.HasSuffix(word, "ch") || strings.HasSuffix(word, "x") ||
 		strings.HasSuffix(word, "z") {
 		return word + "es"
@@ -36,12 +38,12 @@ func Pluralize(word string) string {
 	}
 
 	if strings.HasSuffix(word, "f") {
-		return word[:len(word)-1] + "ves" 
+		return word[:len(word)-1] + "ves"
 	}
 	if strings.HasSuffix(word, "fe") {
 		return word[:len(word)-2] + "ves"
 	}
-	
+
 	return word + "s"
 }
 
@@ -56,10 +58,13 @@ func ToSnakeCase(s string) string {
 	return strings.ToLower(result.String())
 }
 
-
 func Capitalize(s string) string {
 	if s == "" {
 		return ""
 	}
 	return strings.ToUpper(s[:1]) + strings.ToLower(s[1:])
+}
+
+func TrimTrailingSlash(s string) string {
+	return strings.TrimSuffix(s, "/")
 }


### PR DESCRIPTION
Fixes the issue where using an output directory with a trailing slash (e.g., `--output api/`) results in double slashes in generated import paths.

## Problem
When users provide an output path ending with `/`, the generated files contain invalid import paths:
`github.com/module/output//resource/controllers` (note the `//`)

## Solution
- Added `TrimTrailingSlash()` function to trim trailing slashes from output paths
- Updated all content generation functions (routes, controller, service, repository) to use this function
- Import paths are now correctly formed regardless of trailing slashes

## Testing
- ✅ Tested with trailing slash: `--output test/`
- ✅ Tested without trailing slash: `--output test`
- ✅ Tested with nested paths: `--output path/to/dir/`
- ✅ All imports are correctly formatted