### PR TITLE
Feature: Add version command (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # 🚀 Gogen - Go CRUD Generator CLI
 
-[![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat&logo=go)](https://go.dev/)
-[![Release](https://img.shields.io/github/v/release/zaheershaikh936/gogen)](https://github.com/zaheershaikh936/gogen/releases)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Go Report Card](https://goreportcard.com/badge/github.com/zaheershaikh936/gogen)](https://goreportcard.com/report/github.com/zaheershaikh936/gogen)
+[![Go](https://img.shields.io/badge/Go-00ADD8?logo=go&logoColor=white&style=flat-square)](https://go.dev/)
+[![Fiber](https://img.shields.io/badge/Fiber-00A98F?logo=fiber&logoColor=white&style=flat-square)](https://gofiber.io/)
+[![Gin](https://img.shields.io/badge/Gin-00B140?logo=gin&logoColor=white&style=flat-square)](https://gin-gonic.com/)
+[![Release](https://img.shields.io/github/v/release/zaheershaikh936/gogen?style=flat-square)](https://github.com/zaheershaikh936/gogen/releases)
+[![License](https://img.shields.io/github/license/zaheershaikh936/gogen?style=flat-square)](https://github.com/zaheershaikh936/gogen/blob/main/LICENSE)
+[![Go Report Card](https://goreportcard.com/badge/github.com/zaheershaikh936/gogen?style=flat-square)](https://goreportcard.com/report/github.com/zaheershaikh936/gogen)
+
 
 > A powerful CLI tool to generate complete CRUD resources for **Go Fiber** and **Gin** frameworks with a premium TUI experience and idiomatic naming 💎
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,12 +7,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var Version = "v1.1.0"
+
 var rootCmd = &cobra.Command{
 	Use:   "gogen",
-	Short: "A professional CRUD generator for Go Fiber applications",
-	Long: `Gogen is a powerful CLI tool designed to accelerate Go Fiber web development
-by generating idiomatic CRUD resources including controllers, services, 
-repositories, and routes using clean architecture principles.`,
+	Short: "A professional CLI tool to generate CRUD resources for Go Fiber and Gin",
+	Long: `Gogen - Go CRUD Generator CLI A command-line tool for generating CRUD resource scaffolding for Go Fiber and Gin web frameworks. gogen automates the creation of controllers, services, repositories, and routes.`,
+	// Adding the version field
+	Version: Version, // this enables the --version flag
 }
 
 func Execute() {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+    "fmt"
+    "github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+    Use:   "version",
+    Short: "Print the version of gogen",
+    Run: func(cmd *cobra.Command, args []string) {
+        fmt.Printf("gogen %s\n", Version)
+    },
+}
+
+func init() {
+    rootCmd.AddCommand(versionCmd)
+}	


### PR DESCRIPTION
Closes #15 

- Added `Version` var and set `rootCmd.Version` which enables `gogen --version`
- Created `cmd/version.go` with `gogen version` subcommand
- Registered via init()
- Tested locally: prints version correctly

Tested locally with `gogen.exe --version` and `gogen.exe version` — prints correctly.
Confirmed no build errors after fixes.